### PR TITLE
Update to Bevy 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bevy_screen_diagnostics"
 description = "Bevy plugin for displaying diagnostics on screen."
 documentation = "https://docs.rs/bevy_screen_diagnostics"
-version = "0.4.0"
+version = "0.5.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 keywords = ["gamedev", "bevy", "diagnostics", "debug"]
@@ -15,7 +15,7 @@ default = ["builtin-font"]
 builtin-font = ["bevy/default_font"]
 
 [dependencies]
-bevy = { version = "0.12", default-features = false, features = [
+bevy = { version = "0.13", default-features = false, features = [
     "bevy_text",
     "bevy_ui",
     "bevy_asset",
@@ -23,7 +23,7 @@ bevy = { version = "0.12", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-bevy = { version = "0.12", default-features = true }
+bevy = { version = "0.13", default-features = true }
 
 [profile.dev]
 opt-level = 1

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ You can provide your own font while initialising the `ScreenDiagnosticsPlugin` b
 
 | bevy | bevy_screen_diagnostics |
 | ---- | ----------------------- |
+| 0.13 | 0.5                     |
 | 0.12 | 0.4                     |
 | 0.11 | 0.3                     |
 | 0.10 | 0.2                     |

--- a/examples/custom_diagnostic.rs
+++ b/examples/custom_diagnostic.rs
@@ -1,6 +1,6 @@
 /// Add a custom diagnostic to bevy and to your screen diagnostics
 use bevy::{
-    diagnostic::{Diagnostic, DiagnosticId, Diagnostics, RegisterDiagnostic},
+    diagnostic::{Diagnostic, DiagnosticPath, Diagnostics, RegisterDiagnostic},
     prelude::*,
 };
 
@@ -9,7 +9,7 @@ use bevy_screen_diagnostics::{Aggregate, ScreenDiagnostics, ScreenDiagnosticsPlu
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .register_diagnostic(Diagnostic::new(BOX_COUNT, "particle_count", 20))
+        .register_diagnostic(Diagnostic::new(BOX_COUNT))
         .add_plugins(ScreenDiagnosticsPlugin::default())
         .add_systems(Startup, setup)
         .add_systems(Startup, setup_diagnostic)
@@ -44,7 +44,7 @@ fn setup(mut commands: Commands) {
 }
 
 // For a full explanation on adding custom diagnostics, see: https://github.com/bevyengine/bevy/blob/main/examples/diagnostics/custom_diagnostic.rs
-const BOX_COUNT: DiagnosticId = DiagnosticId::from_u128(123746129308746521389345767461);
+const BOX_COUNT: DiagnosticPath = DiagnosticPath::const_new("box_count");
 
 fn setup_diagnostic(mut onscreen: ResMut<ScreenDiagnostics>) {
     onscreen
@@ -54,5 +54,5 @@ fn setup_diagnostic(mut onscreen: ResMut<ScreenDiagnostics>) {
 }
 
 fn thing_count(mut diagnostics: Diagnostics, parts: Query<&Thing>) {
-    diagnostics.add_measurement(BOX_COUNT, || parts.iter().len() as f64);
+    diagnostics.add_measurement(&BOX_COUNT, || parts.iter().len() as f64);
 }

--- a/examples/runtime_configure.rs
+++ b/examples/runtime_configure.rs
@@ -32,7 +32,7 @@ fn rainbow(mut diags: ResMut<ScreenDiagnostics>, mut hue: Local<f32>) {
 }
 
 fn mouse(
-    buttons: Res<Input<MouseButton>>,
+    buttons: Res<ButtonInput<MouseButton>>,
     mut diags: ResMut<ScreenDiagnostics>,
     mut aggregate_toggle: Local<bool>,
 ) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,7 +321,7 @@ impl ScreenDiagnostics {
         self.diagnostics.remove(&name);
     }
 
-    /// Set the [TextAlignment] and trigger a rebuild
+    /// Set the [JustifyText] and trigger a rebuild
     pub fn set_alignment(&mut self, align: JustifyText) {
         self.text_alignment = align;
         self.layout_changed = true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 use std::{collections::BTreeMap, time::Duration};
 
 use bevy::{
-    diagnostic::{DiagnosticId, Diagnostics, DiagnosticsStore},
+    diagnostic::{DiagnosticPath, DiagnosticsStore},
     prelude::*,
     render::view::RenderLayers,
     text::BreakLineOn,
@@ -143,17 +143,17 @@ pub enum Aggregate {
 /// Example: ``|v| format!("{:.2}", v);`` which limits the decimal places to 1.
 pub type FormatFn = fn(f64) -> String;
 
-/// Resource which maps the name to the [DiagnosticId], [Aggregate] and [ConvertFn]
+/// Resource which maps the name to the [DiagnosticPath], [Aggregate] and [ConvertFn]
 #[derive(Resource)]
 pub struct ScreenDiagnostics {
-    text_alignment: TextAlignment,
+    text_alignment: JustifyText,
     diagnostics: BTreeMap<String, DiagnosticsText>,
     layout_changed: bool,
 }
 impl Default for ScreenDiagnostics {
     fn default() -> Self {
         Self {
-            text_alignment: TextAlignment::Left,
+            text_alignment: JustifyText::Left,
             diagnostics: Default::default(),
             layout_changed: Default::default(),
         }
@@ -162,7 +162,7 @@ impl Default for ScreenDiagnostics {
 
 struct DiagnosticsText {
     name: String,
-    id: DiagnosticId,
+    path: DiagnosticPath,
     agg: Aggregate,
     format: FormatFn,
     show: bool,
@@ -253,7 +253,7 @@ impl ScreenDiagnostics {
     /// Add a diagnostic to be displayed.
     ///
     /// * `name` - The name displayed on-screen. Also used as a key.
-    /// * `diagnostic` - The [DiagnosticId] which is displayed.
+    /// * `path` - The [DiagnosticPath] which is displayed.
 
     /// ```rust
     ///# use bevy::{diagnostic::FrameTimeDiagnosticsPlugin, prelude::*};
@@ -275,7 +275,7 @@ impl ScreenDiagnostics {
     ///         .format(|v| format!("{:.0}", v));
     /// }
     /// ```
-    pub fn add<S>(&mut self, name: S, id: DiagnosticId) -> DiagnosticsTextBuilder
+    pub fn add<S>(&mut self, name: S, path: DiagnosticPath) -> DiagnosticsTextBuilder
     where
         S: Into<String>,
     {
@@ -283,7 +283,7 @@ impl ScreenDiagnostics {
 
         let text = DiagnosticsText {
             name: name.clone(),
-            id,
+            path,
             agg: Aggregate::Value,
             format: |v| format!("{v:.2}"),
             show: true,
@@ -322,7 +322,7 @@ impl ScreenDiagnostics {
     }
 
     /// Set the [TextAlignment] and trigger a rebuild
-    pub fn set_alignment(&mut self, align: TextAlignment) {
+    pub fn set_alignment(&mut self, align: JustifyText) {
         self.text_alignment = align;
         self.layout_changed = true;
     }
@@ -332,7 +332,7 @@ impl ScreenDiagnostics {
             return;
         }
 
-        for mut text_diag in self.diagnostics.values_mut().rev() {
+        for text_diag in self.diagnostics.values_mut().rev() {
             if text_diag.rebuild {
                 self.layout_changed = true;
                 text_diag.rebuild = false;
@@ -359,7 +359,7 @@ impl ScreenDiagnostics {
                 text_diag.edit = false;
             }
 
-            if let Some(diag) = diagnostics.get(text_diag.id) {
+            if let Some(diag) = diagnostics.get(&text_diag.path) {
                 let diag_val = match text_diag.agg {
                     Aggregate::Value => diag.value(),
                     Aggregate::Average => diag.average(),
@@ -379,7 +379,7 @@ impl ScreenDiagnostics {
     fn rebuild(&mut self, font: Res<ScreenDiagnosticsFont>) -> Text {
         let mut sections: Vec<TextSection> = Vec::new();
 
-        for (i, mut text) in self
+        for (i, text) in self
             .diagnostics
             .values_mut()
             .rev()
@@ -392,7 +392,7 @@ impl ScreenDiagnostics {
 
         Text {
             sections,
-            alignment: self.text_alignment,
+            justify: self.text_alignment,
             linebreak_behavior: BreakLineOn::WordBoundary,
         }
     }


### PR DESCRIPTION
- [Rename Input to ButtonInput](https://bevyengine.org/learn/migration-guides/0-12-to-0-13/#rename-input-to-buttoninput)
- [Replace DiagnosticId by DiagnosticPath](https://bevyengine.org/learn/migration-guides/0-12-to-0-13/#replace-diagnosticid-by-diagnosticpath)
- [Rename TextAlignment to JustifyText](https://bevyengine.org/learn/migration-guides/0-12-to-0-13/#rename-textalignment-to-justifytext)
- Removed a few unnecessary `mut` in `impl ScreenDiagnostics`

Changes have been tested against all examples in examples folder.